### PR TITLE
「保存オプション」「保存オプション設定」の説明を改善

### DIFF
--- a/data/plugin_browser/保存オプション.txt
+++ b/data/plugin_browser/保存オプション.txt
@@ -7,4 +7,4 @@
 
 - [[plugin_browser/保存オプション設定]]
 - [[plugin_browser/保存]]
-- [[plugin_browser/読]]』
+- [[plugin_browser/読]]

--- a/data/plugin_browser/保存オプション設定.txt
+++ b/data/plugin_browser/保存オプション設定.txt
@@ -12,4 +12,4 @@
 
 - [[plugin_browser/保存オプション設定]]
 - [[plugin_browser/保存]]
-- [[plugin_browser/読]]』
+- [[plugin_browser/読]]


### PR DESCRIPTION
不自然な `』` を削除。
