### PR TITLE
「plugin_browser/BLOB作成」を改善

### DIFF
--- a/data/plugin_browser/BLOB作成.txt
+++ b/data/plugin_browser/BLOB作成.txt
@@ -12,6 +12,6 @@ BLOBを作成します。
 
 # --- BLOBを得てアップロード ---
 IMG=描画データBLOB変換。
-「https://exmaple.com/index.php?m=upload-b64」へ{"file": BLOB作成([IMG],{"content-type":"image/png"})}をPOSTフォーム送信して表示。
+「https://example.com/index.php?m=upload-b64」へ{"file": BLOB作成([IMG],{"content-type":"image/png"})}をPOSTフォーム送信して表示。
 }}}
 


### PR DESCRIPTION
`exmaple.com` を、例示用ドメインの `example.com` に変更。
