### PR TITLE
「DOM要素全取得」へのリンクを改善

### DIFF
--- a/data/plugin_browser/DOM要素ID取得.txt
+++ b/data/plugin_browser/DOM要素ID取得.txt
@@ -13,5 +13,5 @@ DOM親要素に「
 ▲参考
 
 - [[DOM要素取得:plugin_browser/DOM要素取得]] ... CSSクエリで1つ要素を得る
-- [[DOM要素取得:plugin_browser/DOM要素全取得]] ... CSSクエリで全要素を得る
+- [[DOM要素全取得:plugin_browser/DOM要素全取得]] ... CSSクエリで全要素を得る
 

--- a/data/plugin_browser/DOM要素全取得.txt
+++ b/data/plugin_browser/DOM要素全取得.txt
@@ -19,5 +19,5 @@ DOM親要素に「
 ▲参考
 
 - [[DOM要素取得:plugin_browser/DOM要素取得]] ... CSSクエリで1つ要素を得る
-- [[DOM要素取得:plugin_browser/DOM要素全取得]] ... CSSクエリで全要素を得る
+- [[DOM要素全取得:plugin_browser/DOM要素全取得]] ... CSSクエリで全要素を得る
 

--- a/data/plugin_browser/DOM要素取得.txt
+++ b/data/plugin_browser/DOM要素取得.txt
@@ -15,5 +15,5 @@ Dのテキスト取得して表示。
 ▲参考
 
 - [[DOM要素取得:plugin_browser/DOM要素取得]] ... CSSクエリで1つ要素を得る
-- [[DOM要素取得:plugin_browser/DOM要素全取得]] ... CSSクエリで全要素を得る
+- [[DOM要素全取得:plugin_browser/DOM要素全取得]] ... CSSクエリで全要素を得る
 

--- a/data/plugin_browser/タグ一覧取得.txt
+++ b/data/plugin_browser/タグ一覧取得.txt
@@ -19,5 +19,5 @@ DOM親要素に「
 ▲参考
 
 - [[DOM要素取得:plugin_browser/DOM要素取得]] ... CSSクエリで1つ要素を得る
-- [[DOM要素取得:plugin_browser/DOM要素全取得]] ... CSSクエリで全要素を得る
+- [[DOM要素全取得:plugin_browser/DOM要素全取得]] ... CSSクエリで全要素を得る
 


### PR DESCRIPTION
「DOM要素取得」というテキストで「DOM要素全取得」にリンクが貼られていたのを、「DOM要素全取得」に変更。
