### PR TITLE
「文法/JSプラグインの作り方」を改善

### DIFF
--- a/data/文法/JSプラグインの作り方.txt
+++ b/data/文法/JSプラグインの作り方.txt
@@ -71,8 +71,8 @@ typeプロパティに「var」(変数)や「const」(定数)を指定して、v
 
 {{{
 {
-    { type: 'const', value: 100 }, // @よみがな
-    { type: 'const', value: 100 }, // @よみがな
+    '変数名': { type: 'var', value: 100 }, // @よみがな
+    '定数名': { type: 'const', value: 100 }, // @よみがな
 ....
 }
 }}}


### PR DESCRIPTION
「変数や定数の定義」で同じものが2個並んでいてあまり意味が無さそうだったので、変数と定数を定義する例に変更。
