### PR TITLE
「右トリム」の説明を改善

### DIFF
--- a/data/plugin_system/右トリム.txt
+++ b/data/plugin_system/右トリム.txt
@@ -13,5 +13,5 @@ A2=「def」
 ▲参考
 
 - [[plugin_system/空白除去]]
-- [[plugin_system/右トリム]] ... 同じ
-- [[plugin_system/末尾空白除去]]
+- [[plugin_system/右トリム]]
+- [[plugin_system/末尾空白除去]] ... 同じ


### PR DESCRIPTION
右トリムと右トリムが同じというのは当たり前なので、「同じ」を「末尾空白除去」に付け替え。
