### PR TITLE
Discordのリンクを変更

### DIFF
--- a/data/MenuBar.txt
+++ b/data/MenuBar.txt
@@ -28,11 +28,12 @@
 ▲その他
 - [[📍最近更新:最近更新]]
 - [[📍X:https://x.com/search?q=%23%E3%81%AA%E3%81%A7%E3%81%97%E3%81%93%E3%81%95%E3%82%93&src=typed_query]]
-- [[😊Discord:https://discord.gg/WkaQAxbDaE]]
+- [[😊Discord:https://discord.com/invite/FAtjTQr3kk]]
 
 {{{#rem
 - [[投稿コメントについて]]
 }}}
 
 #counter
+
 


### PR DESCRIPTION
Discordのリンクが無効のようなので、[nadesiko3/README.md](https://github.com/kujirahand/nadesiko3/blob/master/README.md?plain=1) と同じリンク先に変更。
